### PR TITLE
Update bmm8563.c

### DIFF
--- a/src/bmm8563.c
+++ b/src/bmm8563.c
@@ -94,7 +94,7 @@ void bmm8563_getTime(rtc_date_t* data) {
     data->minute = BCD2Byte(time_buf[1] & 0x7f);
     data->hour = BCD2Byte(time_buf[2] & 0x3f);
     data->day = BCD2Byte(time_buf[3] & 0x3f);
-    data->month = BCD2Byte(time_buf[5] & 0x0f);
+    data->month = BCD2Byte(time_buf[5] & 0x1f);
     data->year = BCD2Byte(time_buf[6]) + (time_buf[5] & 0x80 ? 1900 : 2000);
 }
 


### PR DESCRIPTION
Fixed the problem that the tenth digit of month disappears when reading registers from RTC.