### PR TITLE
Initialize i2c_config_t

### DIFF
--- a/src/bmm8563.c
+++ b/src/bmm8563.c
@@ -13,7 +13,7 @@
 #define I2C_NUM 0
 
 void i2c_init() {
-    i2c_config_t conf;
+    i2c_config_t conf = {};
     conf.mode             = I2C_MODE_MASTER;
     conf.sda_io_num       = (gpio_num_t)12;
     conf.scl_io_num       = (gpio_num_t)14;


### PR DESCRIPTION
Sets clk_flags to zero making it compatible with never versions of esp32 SDK

`bmm8563_init()` is broken
```
E (314902) i2c: i2c_param_config(684): i2c clock choice is invalid, please check flag and frequency
E (314902) err: esp_err_t = 258, line = 23
E (314903) i2c: i2c driver install error
E (314907) err: esp_err_t = -1, line = 24
```