### PR TITLE
fix i2c error on camera & RTC

### DIFF
--- a/src/utility/RTC8563_Class.cpp
+++ b/src/utility/RTC8563_Class.cpp
@@ -29,7 +29,7 @@ static std::uint8_t byteToBcd2(std::uint8_t value) {
 }
 
 bool RTC8563_Class::begin() {
-    _i2c.begin(&Wire1, 12, 14);
+    _i2c.begin(&Wire, 12, 14);
     _i2c.writeByte(BM8563_I2C_ADDR, 0x00, 0x00);
     return _i2c.writeByte(BM8563_I2C_ADDR, 0x0E, 0x03);
     ;


### PR DESCRIPTION
based of discussions at https://github.com/m5stack/TimerCam-arduino/issues/16, I've fixed i2c initialization error when using RTC (TimerCAM.begin(true) and camera.