### PR TITLE
Fix missing cstdint include in RTC8563 class and battery ADC channel enum conversion error

### DIFF
--- a/src/utility/Power_Class.h
+++ b/src/utility/Power_Class.h
@@ -14,7 +14,7 @@
 #define POWER_LED_PIN  2
 
 #define BAT_ADC_PIN     38
-#define BAT_ADC_CHANNEL ADC1_GPIO38_CHANNEL
+#define BAT_ADC_CHANNEL ADC1_CHANNEL_2
 
 #define BASE_VOLATAGE     3600
 #define SCALE             0.661

--- a/src/utility/RTC8563_Class.h
+++ b/src/utility/RTC8563_Class.h
@@ -13,6 +13,7 @@
 typedef void timezone;
 #endif
 #include <time.h>
+#include <cstdint>
 
 #define BM8563_I2C_ADDR 0x51
 


### PR DESCRIPTION
I purchased the M5Stack TimerCamera F this week and was unable to compile a simple example project, so I tried to identify the problem.

1. Missing cstdint include in RTC8563 class (reported in #23)
The fix was mentioned in https://github.com/m5stack/TimerCam-arduino/issues/23#issuecomment-2231872565

2. Battery ADC channel enum conversion error (reported in #27)
This seems to be a minor issue with the compiler, but I'm not really sure.
I managed to fix it myself by looking at the ESP-IDF code and documentation.
The `ADC1_GPIO38_CHANNEL` define appears to be equivalent to `ADC1_CHANNEL_2`, which is an `adc1_channel_t` enum value. This enum type is required for calling the `adc1_config_channel_atten` and `adc1_get_raw` functions.

References:
- https://github.com/espressif/esp-idf/blob/master/components/soc/esp32/include/soc/adc_channel.h#L16
- https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-reference/peripherals/adc.html#_CPPv414ADC1_CHANNEL_2

>I've marked the PR as 'draft' because I'm suggesting workarounds for people who may encounter the same unsolved problems as me. I don't know if these changes are the best solutions myself.